### PR TITLE
refactor(main): ignore .kit/ on main branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ farmdata2_modules/**/cypress/videos/*
 **/__pycache__
 
 .DS_Store
+
+## .kit should only exist in Instructor branch.
+.kit/


### PR DESCRIPTION
__Pull Request Description__

The .kit/ directory and its contents should only be used by the instructor. And so should not exist in the Instructor branch. But when switching between the Instructor and main branch, sometimes .kit/ is left behind, and there is a chance of inadvertently committing it to the wrong branch. So this commit tells git to ignore .kit on the main branch.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
