### PR TITLE
feat(main): check origin is not upstream

### DIFF
--- a/.kitty/init.bash
+++ b/.kitty/init.bash
@@ -17,15 +17,10 @@ if [[ "$ORIGIN" == *"$KIT_UPSTREAM_NAME"* ]] ; then
     printf "\xF0\x9F\x98\xBA Meow, Kitty here!\n"
     echo
     echo "Oops, I think you have cloned the upstream repository instead of your"
-    echo "fork. Use the following command below to inspect your local"
-    echo "repository's remotes."
+    echo "fork. But don't worry. You can fix it!"
     echo
-    echo "    git remote -v"
-    echo
-    echo "Look for the 'origin' remote. If its URL points to upstream and not"
-    echo "your fork, you have a problem. But don't worry. You can fix it!"
-    echo "You'll need to delete your local repository, then navigate to your"
-    echo "fork on GitHub, copy its clone URL, and then try clone using that"
-    echo "URL. Don't forget to initialize me again so I can help out."
+    echo "1. Delete your local repository."
+    echo "2. Navigate to your fork on GitHub and copy its clone URL."
+    echo "3. Clone your fork using its clone URL."
     echo "*********************************************************************"
 fi

--- a/.kitty/init.bash
+++ b/.kitty/init.bash
@@ -3,13 +3,13 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "${SCRIPT_DIR}"
 
-# Install git hooks
-# cp .hooks/pre-commit ../.git/hooks/pre-commit
-# cp .hooks/pre-merge-commit ../.git/hooks/pre-merge-commit
-# cp .hooks/pre-rebase ../.git/hooks/pre-rebase
-# git config branch.main.mergeoptions "--no-ff"
+## Install git hooks
+cp .hooks/pre-commit ../.git/hooks/pre-commit
+cp .hooks/pre-merge-commit ../.git/hooks/pre-merge-commit
+cp .hooks/pre-rebase ../.git/hooks/pre-rebase
+git config branch.main.mergeoptions "--no-ff"
 
-# Load environment variables including KIT_UPSTREAM_NAME
+## Check origin remote URL does not contain upstream's name.
 source ./env
 ORIGIN="$(git remote -v | grep origin)"
 if [[ "$ORIGIN" == *"$KIT_UPSTREAM_NAME"* ]] ; then

--- a/.kitty/init.bash
+++ b/.kitty/init.bash
@@ -4,7 +4,28 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd "${SCRIPT_DIR}"
 
 # Install git hooks
-cp .hooks/pre-commit ../.git/hooks/pre-commit
-cp .hooks/pre-merge-commit ../.git/hooks/pre-merge-commit
-cp .hooks/pre-rebase ../.git/hooks/pre-rebase
-git config branch.main.mergeoptions "--no-ff"
+# cp .hooks/pre-commit ../.git/hooks/pre-commit
+# cp .hooks/pre-merge-commit ../.git/hooks/pre-merge-commit
+# cp .hooks/pre-rebase ../.git/hooks/pre-rebase
+# git config branch.main.mergeoptions "--no-ff"
+
+# Load environment variables including KIT_UPSTREAM_NAME
+source ./env
+ORIGIN="$(git remote -v | grep origin)"
+if [[ "$ORIGIN" == *"$KIT_UPSTREAM_NAME"* ]] ; then
+    echo "*********************************************************************"
+    printf "\xF0\x9F\x98\xBA Meow, Kitty here!\n"
+    echo
+    echo "Oops, I think you have cloned the upstream repository instead of your"
+    echo "fork. Use the following command below to inspect your local"
+    echo "repository's remotes."
+    echo
+    echo "    git remote -v"
+    echo
+    echo "Look for the 'origin' remote. If its URL points to upstream and not"
+    echo "your fork, you have a problem. But don't worry. You can fix it!"
+    echo "You'll need to delete your local repository, then navigate to your"
+    echo "fork on GitHub, copy its clone URL, and then try clone using that"
+    echo "URL. Don't forget to initialize me again so I can help out."
+    echo "*********************************************************************"
+fi


### PR DESCRIPTION
__Pull Request Description__

Checks that the origin remote URL does not contain the name of upstream.
If it does, displays a helpful message.

Closes issue https://github.com/HFOSSedu/GitKit-Issues/issues/4

To test:

1. Start with a clone of GitKit.
2. Checkout main-check-origin
2. Create .kitty/env , and place the following line in it
    ```
    KIT_UPSTREAM_NAME="HFOSSedu/GitKit"
    ```
3. Run `.kitty/init.bash`

You should get a message from kitty about `origin` and `upstream`. That's because we set the upstream name to "HFOSSedu/GitKit" and you have clone that same repo locally, so its `origin` is set to a URL that contains that name. This is fine for this project. But in the activity, students should be cloning their fork of the upstream instance.


---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
